### PR TITLE
Update CDVClipboard.m to support iOS11 copying to clipboard

### DIFF
--- a/src/ios/CDVClipboard.m
+++ b/src/ios/CDVClipboard.m
@@ -10,7 +10,7 @@
 		UIPasteboard *pasteboard = [UIPasteboard generalPasteboard];
 		NSString     *text       = [command.arguments objectAtIndex:0];
 
-		[pasteboard setValue:text forPasteboardType:@"public.text"];
+		pasteboard.string = text;
 
 		CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:text];
 		[self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];


### PR DESCRIPTION
Fix copying to clipboard in iOS11.