### PR TITLE
Incorporate fixes from Jigsaw-Code fork

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -33,7 +33,19 @@
         <header-file src="src/ios/CDVClipboard.h" />
         <source-file src="src/ios/CDVClipboard.m" />
     </platform>
+    
+    <!-- OS X -->
+    <platform name="osx">
+        <config-file target="config.xml" parent="/*">
+            <feature name="Clipboard">
+                <param name="ios-package" value="CDVClipboard" />
+            </feature>
+        </config-file>
 
+        <header-file src="src/osx/CDVClipboard.h" />
+        <source-file src="src/osx/CDVClipboard.m" />
+    </platform>
+    
     <!-- Android -->
     <platform name="android">
         <source-file src="src/android/Clipboard.java" target-dir="src/com/verso/cordova/clipboard" />

--- a/src/android/Clipboard.java
+++ b/src/android/Clipboard.java
@@ -38,16 +38,14 @@ public class Clipboard extends CordovaPlugin {
                 callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.ERROR, e.toString()));
             }
         } else if (action.equals(actionPaste)) {
-            if (!clipboard.getPrimaryClipDescription().hasMimeType(ClipDescription.MIMETYPE_TEXT_PLAIN)) {
-                callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.NO_RESULT));
-            }
-
             try {
-                ClipData.Item item = clipboard.getPrimaryClip().getItemAt(0);
-                String text = item.getText().toString();
-
-                if (text == null) text = "";
-
+                String text = "";
+                
+                ClipData clip = clipboard.getPrimaryClip();
+                if (clip != null) {
+                    ClipData.Item item = clip.getItemAt(0);
+                    text = item.getText().toString();
+                }
                 callbackContext.success(text);
 
                 return true;

--- a/src/ios/CDVClipboard.m
+++ b/src/ios/CDVClipboard.m
@@ -21,7 +21,10 @@
 	[self.commandDelegate runInBackground:^{
 		UIPasteboard *pasteboard = [UIPasteboard generalPasteboard];
 		NSString     *text       = [pasteboard valueForPasteboardType:@"public.text"];
-	    
+	    if (text == nil) {
+            text = @"";
+        }
+
 	    CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:text];
 	    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 	}];

--- a/src/osx/CDVClipboard.h
+++ b/src/osx/CDVClipboard.h
@@ -1,0 +1,9 @@
+#import <Foundation/Foundation.h>
+#import <Cordova/CDVPlugin.h>
+
+@interface CDVClipboard : CDVPlugin {}
+
+- (void)copy:(CDVInvokedUrlCommand*)command;
+- (void)paste:(CDVInvokedUrlCommand*)command;
+
+@end

--- a/src/osx/CDVClipboard.m
+++ b/src/osx/CDVClipboard.m
@@ -1,0 +1,34 @@
+#import <Foundation/Foundation.h>
+#import <Cordova/CDVPlugin.h>
+#import <Cordova/CDVPluginResult.h>
+#import "CDVClipboard.h"
+
+@implementation CDVClipboard
+
+- (void)copy:(CDVInvokedUrlCommand*)command {
+	[self.commandDelegate runInBackground:^{
+		NSPasteboard *pasteboard = [NSPasteboard generalPasteboard];
+		NSString *text = [command.arguments objectAtIndex:0];
+
+		[pasteboard clearContents];
+		[pasteboard setString:text forType:NSStringPboardType];
+
+		CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:text];
+		[self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+	}];
+}
+
+- (void)paste:(CDVInvokedUrlCommand*)command {
+	[self.commandDelegate runInBackground:^{
+		NSPasteboard *pasteboard = [NSPasteboard generalPasteboard];
+		NSString *text = [pasteboard stringForType:NSPasteboardTypeString];
+		if (text == nil) {
+			text = @"";
+		}
+
+		CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:text];
+		[self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+	}];
+}
+
+@end


### PR DESCRIPTION
- Add support for osx
- Remove wonky MIMETYPE check in Android paste method
- Add check for `nil` in iOS; return an empty string instead

Of these, the Android MIMETYPE check was the most annoying to us. Calling Paste() would simply not return if someone had copied some HTML from another app. This should at least convert the html to text and return it, or just return an empty string.